### PR TITLE
Fix for testthat 3.3.0

### DIFF
--- a/tests/testthat/test-files.R
+++ b/tests/testthat/test-files.R
@@ -4,5 +4,5 @@ context("files are present and sensible")
 test_that("files are present", {
   expect_that(bgmfiles(), is_a("character"))
   expect_that(length(bgmfiles()), testthat::is_more_than(1L))
-  expect_that(all(file.exists(bgmfiles())), testthat::is_true())
+  expect_true(all(file.exists(bgmfiles())))
 })


### PR DESCRIPTION
`is_true()`, `is_false()`, and `is_null()` have been removed (after several years of deprecation) because they conflict with functions defined elsewhere in the tidyverse. I've updated your code to use the modern equivalent(s).